### PR TITLE
Load firebase secrets from env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+FIREBASE_API_KEY=your_api_key
+FIREBASE_AUTH_DOMAIN=your_auth_domain
+FIREBASE_PROJECT_ID=your_project_id
+FIREBASE_STORAGE_BUCKET=your_storage_bucket
+FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+FIREBASE_APP_ID=your_app_id
+FIREBASE_MEASUREMENT_ID=your_measurement_id

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build/
 # Environment variables
 .env
 .env.local
+env.js
 
 # Package lock files (optional - uncomment if you want to ignore)
 # package-lock.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ A fully-featured interactive Gantt chart application built with vanilla JavaScri
 - Context menus and tooltips
 - Dark mode support
 
+## Firebase Configuration
+
+1. Copy `.env.example` to `.env` and fill in your Firebase credentials.
+2. Running any npm script will automatically generate `env.js` from your `.env` file.
+
 ## Running the Application
 
 ### Option 1: Using npm (with live reload)

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,15 +1,15 @@
 // Firebase configuration
-// IMPORTANT: Replace these values with your actual Firebase project configuration
-// You can find these in your Firebase Console under Project Settings > General > Your apps > SDK setup and configuration
+// Values are loaded from environment variables generated in env.js
+// See README for setup instructions.
 
 const firebaseConfig = {
-  apiKey: "AIzaSyAEAEafI_c-CgVGQM8p3kaqX8uZfj0mSzs",
-  authDomain: "gantt-ff731.firebaseapp.com",
-  projectId: "gantt-ff731",
-  storageBucket: "gantt-ff731.firebasestorage.app",
-  messagingSenderId: "609152736901",
-  appId: "1:609152736901:web:d598996ca3da50f95253ec",
-  measurementId: "G-D1E56LVQN5"
+  apiKey: window._env_.FIREBASE_API_KEY,
+  authDomain: window._env_.FIREBASE_AUTH_DOMAIN,
+  projectId: window._env_.FIREBASE_PROJECT_ID,
+  storageBucket: window._env_.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: window._env_.FIREBASE_MESSAGING_SENDER_ID,
+  appId: window._env_.FIREBASE_APP_ID,
+  measurementId: window._env_.FIREBASE_MEASUREMENT_ID
 };
 
 // Initialize Firebase

--- a/generateEnv.js
+++ b/generateEnv.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '.env');
+  const env = {};
+  if (fs.existsSync(envPath)) {
+    const lines = fs.readFileSync(envPath, 'utf-8').split('\n');
+    for (const line of lines) {
+      const m = line.match(/^\s*([^#=\s]+)\s*=\s*(.*)\s*$/);
+      if (m) {
+        let value = m[2].trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+        env[m[1]] = value;
+      }
+    }
+  }
+  return { ...env, ...process.env };
+}
+
+const keys = [
+  'FIREBASE_API_KEY',
+  'FIREBASE_AUTH_DOMAIN',
+  'FIREBASE_PROJECT_ID',
+  'FIREBASE_STORAGE_BUCKET',
+  'FIREBASE_MESSAGING_SENDER_ID',
+  'FIREBASE_APP_ID',
+  'FIREBASE_MEASUREMENT_ID'
+];
+
+const envVars = loadEnv();
+const out = {};
+keys.forEach(k => { out[k] = envVars[k] || ''; });
+
+const output = 'window._env_ = ' + JSON.stringify(out, null, 2) + ';\n';
+fs.writeFileSync(path.join(__dirname, 'env.js'), output);
+console.log('env.js generated');

--- a/index.html
+++ b/index.html
@@ -158,6 +158,9 @@
     <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-auth-compat.js"></script>
     
+    <!-- Environment Variables -->
+    <script src="env.js"></script>
+
     <!-- Firebase Configuration -->
     <script src="firebase-config.js"></script>
     

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Interactive Gantt Chart Application",
   "main": "index.html",
   "scripts": {
-    "start": "npx http-server -p 8080 -o",
-    "dev": "npx live-server --port=8080"
+    "generate-env": "node generateEnv.js",
+    "start": "npm run generate-env && npx http-server -p 8080 -o",
+    "dev": "npm run generate-env && npx live-server --port=8080"
   },
   "keywords": ["gantt", "chart", "project", "management"],
   "author": "",


### PR DESCRIPTION
## Summary
- inject environment variables in HTML for Firebase config
- reference env values in `firebase-config.js`
- add helper script `generateEnv.js` to create `env.js`
- ignore `env.js` and provide `.env.example`
- document Firebase setup in README

## Testing
- `npm run generate-env`

------
https://chatgpt.com/codex/tasks/task_e_6847082c76188332a4427e884312ff5b